### PR TITLE
 SignUpForm 유효성 검사 추가

### DIFF
--- a/src/components/InputText.vue
+++ b/src/components/InputText.vue
@@ -3,11 +3,13 @@ import { ref } from 'vue';
 
 type InputTextProps = {
   label: string;
+  error?: string;
+  isValid?: boolean;
+  optional?: boolean;
 };
 
 const model = defineModel<string>();
 defineProps<InputTextProps>();
-
 const inputRef = ref<HTMLInputElement | null>(null);
 
 const handleClear = () => {
@@ -17,12 +19,17 @@ const handleClear = () => {
 </script>
 
 <template>
-  <label class="flex flex-col gap-4">
+  <label class="flex flex-col gap-2">
     {{ label }}
     <div class="relative">
       <input
         ref="inputRef"
-        class="w-full border-gray-400 border rounded-md h-10 px-4 hover:border-blue-400 invalid:border-red-500 focus:border-green-400 focus:outline-none"
+        class="w-full border rounded-md h-10 px-4 hover:border-blue-400 focus:outline-none transition-colors"
+        :class="{
+          'border-red-500': error,
+          'border-green-500': !error && isValid && model,
+          'border-gray-400': !error && (!isValid || !model),
+        }"
         type="text"
         autocomplete="off"
         v-model="model"
@@ -36,5 +43,6 @@ const handleClear = () => {
         ✕
       </button>
     </div>
+    <span v-if="error" class="text-sm text-red-500">{{ error }}</span>
   </label>
 </template>

--- a/src/components/InputText.vue
+++ b/src/components/InputText.vue
@@ -1,15 +1,13 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-type InputTextProps = {
+interface InputTextProps {
   label: string;
   error?: string;
   isValid?: boolean;
-  optional?: boolean;
-};
-
-const model = defineModel<string>();
+}
 defineProps<InputTextProps>();
+const model = defineModel<string>();
 const inputRef = ref<HTMLInputElement | null>(null);
 
 const handleClear = () => {
@@ -24,25 +22,30 @@ const handleClear = () => {
     <div class="relative">
       <input
         ref="inputRef"
-        class="w-full border rounded-md h-10 px-4 hover:border-blue-400 focus:outline-none transition-colors"
-        :class="{
-          'border-red-500': error,
-          'border-green-500': !error && isValid && model,
-          'border-gray-400': !error && (!isValid || !model),
-        }"
+        v-model="model"
         type="text"
         autocomplete="off"
-        v-model="model"
+        :class="[
+          'w-full border rounded-md h-10 px-4 transition-colors',
+          'hover:border-blue-400 focus:outline-none',
+          {
+            'border-red-500': !!error,
+            'border-green-500': !error && isValid && model,
+            'border-gray-400': !error && (!isValid || !model),
+          },
+        ]"
       />
       <button
         v-if="model"
         type="button"
-        class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
         @click="handleClear"
+        class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
       >
         ✕
       </button>
     </div>
-    <span v-if="error" class="text-sm text-red-500">{{ error }}</span>
+    <span v-if="error" class="text-sm text-red-500">
+      {{ error }}
+    </span>
   </label>
 </template>

--- a/src/components/SignUpForm.vue
+++ b/src/components/SignUpForm.vue
@@ -1,21 +1,102 @@
 <script setup lang="ts">
-import { ref } from "vue";
-import InputText from "./InputText.vue";
-const userId = ref("");
-const name = ref("");
-const organization = ref("");
+import { ref, computed } from 'vue';
+import InputText from './InputText.vue';
+
+const userId = ref('');
+const name = ref('');
+const organization = ref('');
+
+const userIdDirty = ref(false);
+const nameDirty = ref(false);
+const organizationDirty = ref(false);
+
+const handleUserIdInput = () => {
+  userIdDirty.value = true;
+};
+
+const handleNameInput = () => {
+  nameDirty.value = true;
+};
+
+const handleOrganizationInput = () => {
+  organizationDirty.value = true;
+};
+
+const isValidUserId = computed(() => {
+  if (!userId.value) return false;
+  return /^[a-zA-Z0-9]+$/.test(userId.value);
+});
+
+const isValidName = computed(() => {
+  if (!name.value) return false;
+  return !/[\\/:*?"<>|]/.test(name.value);
+});
+
+const isValidOrganization = computed(() => {
+  return !/[\\/:*?"<>|]/.test(organization.value);
+});
+
+const isFormValid = computed(() => {
+  return isValidUserId.value && isValidName.value && isValidOrganization.value;
+});
+
+const userIdError = computed(() => {
+  if (!userIdDirty.value) return '';
+  if (!userId.value) return 'ID를 입력해주세요';
+  if (!isValidUserId.value) return '알파벳과 숫자만 사용 가능합니다';
+  return '';
+});
+
+const nameError = computed(() => {
+  if (!nameDirty.value) return '';
+  if (!name.value) return '이름을 입력해주세요';
+  if (!isValidName.value) return '특수문자 \\ / : * ? " < > | 는 사용할 수 없습니다';
+  return '';
+});
+
+const organizationError = computed(() => {
+  if (!organizationDirty.value) return '';
+  if (!organization.value) return false;
+  if (!isValidOrganization.value) return '특수문자 \\ / : * ? " < > | 는 사용할 수 없습니다';
+  return '';
+});
+
 const handleSubmit = () => {
-  alert(`User ID: ${userId.value}
-Name: ${name.value}
-Organization: ${organization.value}`);
+  userIdDirty.value = true;
+  nameDirty.value = true;
+  organizationDirty.value = true;
+
+  if (!isFormValid.value) {
+    return;
+  }
+
+  alert(`User ID: ${userId.value}\nName: ${name.value}\nOrganization: ${organization.value}`);
 };
 </script>
 
 <template>
   <form class="flex flex-col gap-4 py-4" @submit.prevent="handleSubmit">
-    <InputText label="User ID" v-model="userId" />
-    <InputText label="Name" v-model="name" />
-    <InputText label="Organization" v-model="organization" />
-    <button class="bg-blue-500 text-white px-4 py-2 rounded-md">Submit</button>
+    <InputText
+      label="User ID"
+      v-model="userId"
+      :error="userIdError"
+      :is-valid="isValidUserId"
+      @input="handleUserIdInput"
+    />
+    <InputText label="Name" v-model="name" :error="nameError" :is-valid="isValidName" @input="handleNameInput" />
+    <InputText
+      label="Organization"
+      v-model="organization"
+      :error="organizationError"
+      :is-valid="isValidOrganization"
+      :optional="true"
+      @input="handleOrganizationInput"
+    />
+    <button
+      class="bg-blue-500 text-white px-4 py-2 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+      :disabled="!isFormValid"
+    >
+      Submit
+    </button>
   </form>
 </template>

--- a/src/composables/useFormValidation.ts
+++ b/src/composables/useFormValidation.ts
@@ -1,0 +1,36 @@
+import { computed, type Ref } from 'vue';
+import { VALIDATION_PATTERNS } from '@/constants/validation';
+
+interface FormData {
+  userId: string;
+  name: string;
+  organization: string;
+}
+
+export function useFormValidation(formData: Ref<FormData>) {
+  const isValidUserId = computed(() => {
+    const { userId } = formData.value;
+    return userId && VALIDATION_PATTERNS.userId.test(userId);
+  });
+
+  const isValidName = computed(() => {
+    const { name } = formData.value;
+    return name && VALIDATION_PATTERNS.name.test(name);
+  });
+
+  const isValidOrganization = computed(() => {
+    const { organization } = formData.value;
+    return !organization || VALIDATION_PATTERNS.organization.test(organization);
+  });
+
+  const isFormValid = computed(() => {
+    return isValidUserId.value && isValidName.value && isValidOrganization.value;
+  });
+
+  return {
+    isValidUserId,
+    isValidName,
+    isValidOrganization,
+    isFormValid,
+  };
+}

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -1,0 +1,19 @@
+export const VALIDATION_PATTERNS = {
+  userId: /^[a-zA-Z0-9]+$/,
+  name: /^[^\\/:*?"<>|]+$/,
+  organization: /^[^\\/:*?"<>|]*$/,
+};
+
+export const VALIDATION_MESSAGES = {
+  userId: {
+    required: 'ID를 입력해주세요',
+    pattern: '알파벳과 숫자만 사용 가능합니다',
+  },
+  name: {
+    required: '이름을 입력해주세요',
+    pattern: '특수문자 \\ / : * ? " < > | 는 사용할 수 없습니다',
+  },
+  organization: {
+    pattern: '특수문자 \\ / : * ? " < > | 는 사용할 수 없습니다',
+  },
+};


### PR DESCRIPTION
**작업내용**
SignUpForm에 유효성 검사를 추가하고, 모든 필드가 유효할 때만 제출될 수 있도록 구현했습니다.

**주요 변경사항**
각 필드별 유효성 검사 조건 추가
- User ID: 알파벳, 숫자만 허용 (필수)
- Name: 특수문자 제한 (필수)
- Organization: 특수문자 제한 (선택)

**구현 상세**
- computed를 사용하여 각 필드별 유효성 검사 로직 구현
- ref를 사용하여 각 필드의 'dirty' 상태 관리 (최초 입력 시점 추적)